### PR TITLE
fix: Update tsconfig.node.json for Vercel build

### DIFF
--- a/chipchip-sgl-tracker/tsconfig.node.json
+++ b/chipchip-sgl-tracker/tsconfig.node.json
@@ -6,7 +6,7 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "noEmit": true
+    "noEmit": false
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
This commit ensures that tsconfig.node.json has noEmit set to false to prevent TS6310 error during Vercel deployment.

Includes all previous features:
- Sales Team Management
- Lead List (add, edit, promote, CSV import/export)
- Onboarded Leaders (list, edit, follow-up, CSV export)
- Performance Dashboard (metrics, filters, cohort insights)
- Daily Check-In

General behaviors like phone normalization, toasts, and basic branding are included.